### PR TITLE
sorting files

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,7 @@ if has_gpio:
 
 FILES = []
 for root, dirs, files in os.walk(os.path.abspath(AUDIO_PATH)):
-    for file in files:
+    for file in sorted(files):
         if file.endswith(".mp3"):
             logger.debug('Found matching file: {}'.format(file))
             FILES.append((os.path.join(root, file),


### PR DESCRIPTION
The files inside the audio folder wasn't added in order (at least on my install RPI 3B+ with Raspbian Buster)

```
DEBUG:root:Found matching file: 02 Wave 103.mp3
DEBUG:root:Found matching file: 07 Espantoso.mp3
DEBUG:root:Found matching file: 01 V-Rock.mp3
DEBUG:root:Found matching file: 06 Fever 105.mp3
DEBUG:root:Found matching file: 03 Emotion 98.3.mp3
DEBUG:root:Found matching file: 04 Flash FM.mp3
DEBUG:root:Found matching file: 05 Pirate Radio.mp3
```

just changing `for file in files:` to `for file in sorted(files):`does the trick 

```
DEBUG:root:Found matching file: 01 V-Rock.mp3
DEBUG:root:Found matching file: 02 Wave 103.mp3
DEBUG:root:Found matching file: 03 Emotion 98.3.mp3
DEBUG:root:Found matching file: 04 Flash FM.mp3
DEBUG:root:Found matching file: 05 Pirate Radio.mp3
DEBUG:root:Found matching file: 06 Fever 105.mp3
DEBUG:root:Found matching file: 07 Espantoso.mp3
```
